### PR TITLE
Prevent crash when using CMake 3.17+

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,10 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
+if(POLICY CMP0100)
+  cmake_policy(SET CMP0100 NEW)
+endif()
+
 project(openMVG C CXX)
 
 # guard against in-source builds


### PR DESCRIPTION
CMake has changed the way it processes `.hh` files, which
comes into conflict with how OpenMVG wants to do it. We 
tell CMake to go ahead and do its thing. Note that this will 
have no impact when using older CMakes.