### PR TITLE
Change `Image_describer::Set_configuration_preset`

### DIFF
--- a/src/openMVG/features/image_describer.hpp
+++ b/src/openMVG/features/image_describer.hpp
@@ -41,7 +41,7 @@ public:
   @return True if configuration succeed.
   */
   virtual bool Set_configuration_preset(EDESCRIBER_PRESET preset,
-                                        float scale) = 0;
+                                        float scale=1.0) = 0;
 
   /**
   @brief Detect regions on the image and compute their attributes (description)


### PR DESCRIPTION
[This is a warmed-over version of #3 from prior to the re-sync with `openMVG/openMVG`]

Classes derived from Image_describer were changed to have default
arguments for scale in their Set_configuration_preset declarations,
however the base class was not changed. This is problematic since we
only ever seem to call Set_configuration_preset through the base class.
This changes the base class to use the same default argument as its
derived classes; it’s unclear how this was ever able to compile without
this change.